### PR TITLE
[BUG] Fix `UIApplication.openURL(_:)` deprecation

### DIFF
--- a/FitAnalytics-WebWidget/FITAWebWidget.m
+++ b/FitAnalytics-WebWidget/FITAWebWidget.m
@@ -416,7 +416,9 @@ typedef void (^WidgetMessageCallback)(id, NSError *);
         decisionHandler(WKNavigationActionPolicyCancel);
     }
     else if (navigationAction.navigationType == WKNavigationTypeLinkActivated) {
-        [[UIApplication sharedApplication] openURL:[navigationAction.request URL]];
+        [[UIApplication sharedApplication] openURL:[navigationAction.request URL]
+                                           options:@{}
+                                 completionHandler:nil];
         decisionHandler(WKNavigationActionPolicyCancel);
     }
     else {


### PR DESCRIPTION
Since `UIApplication.openURL(:)` is deprecated: first deprecated in iOS 10.0 then in iOS 18 it stops working due ⏬ 
> BUG IN CLIENT OF UIKIT: The caller of UIApplication.openURL(_:) needs to migrate to the non-deprecated UIApplication.open(_:options:completionHandler:). Force returning false (NO).

and since the link opening is broken at the moment last iOS version, so this PR fixes the behavior implementing:
```
[[UIApplication sharedApplication] openURL:[navigationAction.request URL]
                                           options:@{}
                                 completionHandler:nil];
```


